### PR TITLE
Add TLS checks support

### DIFF
--- a/res_consul_discovery.conf.sample
+++ b/res_consul_discovery.conf.sample
@@ -10,3 +10,5 @@ discovery_port=5060
 discovery_interface=eth0 ;only use if discovery_ip is auto
 check=true
 check_http_port=8888
+check_tls=false
+check_tls_skip_verify=false


### PR DESCRIPTION
Added params to config:
- `check_tls` - use HTTPS (TLS) instead insecure HTTP connection;
- `check_tls_server_name` - check with [TLSServerName](https://www.consul.io/api-docs/v1.12.x/agent/check#tlsservername) Consul param;
- `check_tls_skip_verify` - check with [TLSSkipVerify](https://www.consul.io/api-docs/v1.12.x/agent/check#tlsskipverify) Consul param.

Also refactored `httpstatus_check` struct allocation. There was accessing to unallocated memory while filling `checks` in some environments.

See also: [Add tls_server_name and tls_skip_verify params to ast_consul_service_check](https://github.com/wazo-platform/wazo-res-consul/pull/6).